### PR TITLE
fix: reorder date patterns so 'modified today' and 'created today' work

### DIFF
--- a/src/commands/find.ts
+++ b/src/commands/find.ts
@@ -67,18 +67,18 @@ function parseQuery(query: string): {
     result.assigneeFilter = 'empty';
   }
   
-  // Date patterns
-  if (lowerQuery.includes('overdue') || lowerQuery.includes('vencid') || 
+  // Date patterns (most specific first to avoid greedy matching)
+  if (lowerQuery.includes('modified today') || (lowerQuery.includes('modificad') && lowerQuery.includes('hoy'))) {
+    result.dateFilter = { type: 'last_edited_today' };
+  } else if (lowerQuery.includes('created today') || (lowerQuery.includes('cread') && lowerQuery.includes('hoy'))) {
+    result.dateFilter = { type: 'created_today' };
+  } else if (lowerQuery.includes('overdue') || lowerQuery.includes('vencid') ||
       lowerQuery.includes('past due') || lowerQuery.includes('atrasad')) {
     result.dateFilter = { type: 'before', value: new Date().toISOString().split('T')[0] };
-  } else if (lowerQuery.includes('today') || lowerQuery.includes('hoy')) {
-    result.dateFilter = { type: 'equals', value: new Date().toISOString().split('T')[0] };
   } else if (lowerQuery.includes('this week') || lowerQuery.includes('esta semana')) {
     result.dateFilter = { type: 'this_week' };
-  } else if (lowerQuery.includes('modified today') || lowerQuery.includes('modificad') && lowerQuery.includes('hoy')) {
-    result.dateFilter = { type: 'last_edited_today' };
-  } else if (lowerQuery.includes('created today') || lowerQuery.includes('cread') && lowerQuery.includes('hoy')) {
-    result.dateFilter = { type: 'created_today' };
+  } else if (lowerQuery.includes('today') || lowerQuery.includes('hoy')) {
+    result.dateFilter = { type: 'equals', value: new Date().toISOString().split('T')[0] };
   }
   
   // Priority patterns

--- a/test/commands/find.test.ts
+++ b/test/commands/find.test.ts
@@ -189,52 +189,33 @@ describe('Find Command', () => {
       }));
     });
 
-    // NOTE: These tests expose a bug - "modified today" and "created today"
-    // patterns never match because "today" pattern is checked first.
-    // Tests adjusted to match actual behavior.
-    it('should find items modified today (currently matches "today" instead)', async () => {
-      const dbWithDate = {
-        ...mockDatabase,
-        properties: {
-          ...mockDatabase.properties,
-          'Due Date': { id: 'due', name: 'Due Date', type: 'date' },
-        },
-      };
-      mockClient.get.mockResolvedValue(dbWithDate);
+    it('should find items modified today using timestamp filter', async () => {
+      mockClient.get.mockResolvedValue(mockDatabase);
       mockClient.post.mockResolvedValue(createPaginatedResult([]));
 
       await program.parseAsync(['node', 'test', 'find', 'modified today', '--database', 'db-123']);
 
-      // BUG: Should use timestamp filter, but "today" pattern matches first
       expect(mockClient.post).toHaveBeenCalledWith('databases/db-123/query', expect.objectContaining({
         filter: expect.objectContaining({
-          property: 'Due Date',
-          date: expect.objectContaining({
-            equals: expect.any(String),
+          timestamp: 'last_edited_time',
+          last_edited_time: expect.objectContaining({
+            on_or_after: expect.any(String),
           }),
         }),
       }));
     });
 
-    it('should find items created today (currently matches "today" instead)', async () => {
-      const dbWithDate = {
-        ...mockDatabase,
-        properties: {
-          ...mockDatabase.properties,
-          'Due Date': { id: 'due', name: 'Due Date', type: 'date' },
-        },
-      };
-      mockClient.get.mockResolvedValue(dbWithDate);
+    it('should find items created today using timestamp filter', async () => {
+      mockClient.get.mockResolvedValue(mockDatabase);
       mockClient.post.mockResolvedValue(createPaginatedResult([]));
 
       await program.parseAsync(['node', 'test', 'find', 'created today', '--database', 'db-123']);
 
-      // BUG: Should use timestamp filter, but "today" pattern matches first
       expect(mockClient.post).toHaveBeenCalledWith('databases/db-123/query', expect.objectContaining({
         filter: expect.objectContaining({
-          property: 'Due Date',
-          date: expect.objectContaining({
-            equals: expect.any(String),
+          timestamp: 'created_time',
+          created_time: expect.objectContaining({
+            on_or_after: expect.any(String),
           }),
         }),
       }));


### PR DESCRIPTION
## Summary

Fixes #6

- `modified today` and `created today` queries were silently falling through to the generic `today` pattern, filtering by due date instead of using timestamp filters
- Root cause: pattern matching checked `today` before the more specific `modified today` / `created today`
- Also fixes operator precedence bug in Spanish patterns (`lowerQuery.includes('modificad') && lowerQuery.includes('hoy')` needed parentheses)

## Changes

- Reorder date pattern checks: specific patterns (`modified today`, `created today`) before generic (`today`)
- Add missing parentheses around `&&` conditions in Spanish patterns
- Update tests to assert correct behavior instead of documenting the bug