### PR TITLE
feat: add rate limiting and exponential backoff to API client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -10,9 +10,15 @@ import * as os from 'os';
 const NOTION_API_BASE = 'https://api.notion.com/v1';
 const NOTION_VERSION = '2022-06-28'; // Stable version
 
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_REQUESTS_PER_SECOND = 3;
+const MIN_RETRY_DELAY_MS = 500;
+
 export interface NotionClientOptions {
   token: string;
   version?: string;
+  maxRetries?: number;
+  requestsPerSecond?: number;
 }
 
 export interface RequestOptions {
@@ -21,20 +27,49 @@ export interface RequestOptions {
   query?: Record<string, string | number | boolean | undefined>;
 }
 
+class RateLimiter {
+  private timestamps: number[] = [];
+  private maxRequests: number;
+
+  constructor(requestsPerSecond: number) {
+    this.maxRequests = requestsPerSecond;
+  }
+
+  async wait(): Promise<void> {
+    const now = Date.now();
+    // Remove timestamps older than 1 second
+    this.timestamps = this.timestamps.filter(t => now - t < 1000);
+
+    if (this.timestamps.length >= this.maxRequests) {
+      const oldestInWindow = this.timestamps[0];
+      const waitMs = 1000 - (now - oldestInWindow);
+      if (waitMs > 0) {
+        await new Promise(resolve => setTimeout(resolve, waitMs));
+      }
+    }
+
+    this.timestamps.push(Date.now());
+  }
+}
+
 export class NotionClient {
   private token: string;
   private version: string;
+  private maxRetries: number;
+  private rateLimiter: RateLimiter;
 
   constructor(options: NotionClientOptions) {
     this.token = options.token;
     this.version = options.version || NOTION_VERSION;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.rateLimiter = new RateLimiter(options.requestsPerSecond ?? DEFAULT_REQUESTS_PER_SECOND);
   }
 
   async request<T = unknown>(path: string, options: RequestOptions = {}): Promise<T> {
     const { method = 'GET', body, query } = options;
 
     let url = `${NOTION_API_BASE}/${path}`;
-    
+
     if (query) {
       const params = new URLSearchParams();
       for (const [key, value] of Object.entries(query)) {
@@ -54,19 +89,65 @@ export class NotionClient {
       'Content-Type': 'application/json',
     };
 
-    const response = await fetch(url, {
-      method,
-      headers,
-      body: body ? JSON.stringify(body) : undefined,
-    });
+    let lastError: Error | null = null;
 
-    if (!response.ok) {
-      const error = await response.json().catch(() => ({}));
-      const message = (error as { message?: string }).message || response.statusText;
-      throw new Error(`Notion API Error (${response.status}): ${message}`);
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      await this.rateLimiter.wait();
+
+      try {
+        const response = await fetch(url, {
+          method,
+          headers,
+          body: body ? JSON.stringify(body) : undefined,
+        });
+
+        // Rate limited: respect Retry-After header
+        if (response.status === 429) {
+          const retryAfter = response.headers.get('Retry-After');
+          const delayMs = retryAfter
+            ? parseFloat(retryAfter) * 1000
+            : MIN_RETRY_DELAY_MS * Math.pow(2, attempt);
+
+          if (attempt < this.maxRetries) {
+            await new Promise(resolve => setTimeout(resolve, delayMs));
+            continue;
+          }
+        }
+
+        // Server errors: retry with backoff
+        if (response.status >= 500 && attempt < this.maxRetries) {
+          await new Promise(resolve =>
+            setTimeout(resolve, MIN_RETRY_DELAY_MS * Math.pow(2, attempt))
+          );
+          continue;
+        }
+
+        if (!response.ok) {
+          const error = await response.json().catch(() => ({}));
+          const message = (error as { message?: string }).message || response.statusText;
+          throw new Error(`Notion API Error (${response.status}): ${message}`);
+        }
+
+        return response.json() as Promise<T>;
+      } catch (error) {
+        lastError = error as Error;
+
+        // Don't retry client-side errors (4xx) except 429
+        if (lastError.message.includes('Notion API Error (4')) {
+          throw lastError;
+        }
+
+        // Retry network errors
+        if (attempt < this.maxRetries) {
+          await new Promise(resolve =>
+            setTimeout(resolve, MIN_RETRY_DELAY_MS * Math.pow(2, attempt))
+          );
+          continue;
+        }
+      }
     }
 
-    return response.json() as Promise<T>;
+    throw lastError || new Error('Request failed after retries');
   }
 
   // Convenience methods

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -186,20 +186,50 @@ describe('NotionClient', () => {
       );
     });
 
-    it('should handle 429 Rate Limited', async () => {
+    it('should retry on 429 Rate Limited and throw after max retries', async () => {
       const { NotionClient } = await import('../src/client');
-      const client = new NotionClient({ token: 'test_token' });
+      const client = new NotionClient({ token: 'test_token', maxRetries: 1 });
 
       global.fetch = mockNotionError(429, 'Rate limited');
 
       await expect(client.request('search')).rejects.toThrow(
         'Notion API Error (429): Rate limited'
       );
+      // 1 initial + 1 retry = 2 calls
+      expect(global.fetch).toHaveBeenCalledTimes(2);
     });
 
-    it('should handle 500 Internal Server Error', async () => {
+    it('should retry on 500 and succeed on second attempt', async () => {
       const { NotionClient } = await import('../src/client');
-      const client = new NotionClient({ token: 'test_token' });
+      const client = new NotionClient({ token: 'test_token', maxRetries: 2 });
+
+      let callCount = 0;
+      global.fetch = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error',
+            headers: new Headers(),
+            json: () => Promise.resolve({ message: 'Internal server error' }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: 'page-123' }),
+        });
+      });
+
+      const result = await client.request('pages/123');
+      expect(result).toEqual({ id: 'page-123' });
+      expect(callCount).toBe(2);
+    });
+
+    it('should throw 500 after exhausting retries', async () => {
+      const { NotionClient } = await import('../src/client');
+      const client = new NotionClient({ token: 'test_token', maxRetries: 0 });
 
       global.fetch = mockNotionError(500, 'Internal server error');
 


### PR DESCRIPTION
## Summary

Fixes #7

Without rate limiting, bulk operations, exports, and batch commands fail on large datasets because the Notion API enforces a 3 req/s limit.

## Changes

- Add `RateLimiter` class with token bucket algorithm (3 req/s default)
- Automatic retry with exponential backoff on 429 responses (respects `Retry-After` header)
- Automatic retry on 5xx server errors
- Client errors (4xx except 429) are NOT retried
- Network errors (timeouts, connection refused) are retried
- Configurable via `maxRetries` and `requestsPerSecond` in client options
- All existing commands benefit transparently since they all use the shared client

## Test plan

- [x] 429 responses are retried up to maxRetries
- [x] 500 errors recover on second attempt
- [x] 500 errors throw after exhausting retries
- [x] 4xx client errors are thrown immediately (no retry)
- [x] All 32 existing client tests pass