### PR TITLE
feat: parallel batch operations with configurable concurrency

### DIFF
--- a/src/commands/batch.ts
+++ b/src/commands/batch.ts
@@ -3,7 +3,7 @@
  * Optimized for AI agents to reduce tool calls
  */
 import { Command } from 'commander';
-import { getClient } from '../client.js';
+import { getClient, NotionClient } from '../client.js';
 import { formatOutput } from '../utils/format.js';
 
 interface BatchOperation {
@@ -20,6 +20,125 @@ interface BatchResult {
   success: boolean;
   result?: unknown;
   error?: string;
+  durationMs?: number;
+}
+
+async function executeOperation(client: NotionClient, op: BatchOperation): Promise<unknown> {
+  switch (op.op) {
+    case 'get':
+      if (op.type === 'page') return client.get(`pages/${op.id}`);
+      if (op.type === 'database') return client.get(`databases/${op.id}`);
+      if (op.type === 'block') return client.get(`blocks/${op.id}`);
+      break;
+
+    case 'create':
+      if (op.type === 'page') {
+        return client.post('pages', {
+          parent: op.data?.parent_type === 'page'
+            ? { page_id: op.parent }
+            : { database_id: op.parent },
+          properties: op.data?.properties || {},
+          children: op.data?.children || [],
+        });
+      }
+      if (op.type === 'database') {
+        return client.post('databases', {
+          parent: { page_id: op.parent },
+          title: op.data?.title || [],
+          properties: op.data?.properties || {},
+        });
+      }
+      break;
+
+    case 'update':
+      if (op.type === 'page') return client.patch(`pages/${op.id}`, op.data || {});
+      if (op.type === 'database') return client.patch(`databases/${op.id}`, op.data || {});
+      if (op.type === 'block') return client.patch(`blocks/${op.id}`, op.data || {});
+      break;
+
+    case 'delete':
+      if (op.type === 'block') return client.delete(`blocks/${op.id}`);
+      return client.patch(`pages/${op.id}`, { archived: true });
+
+    case 'query':
+      if (op.type === 'database') {
+        return client.post(`databases/${op.id}/query`, op.data || {});
+      }
+      break;
+
+    case 'append':
+      if (op.type === 'block') {
+        return client.patch(`blocks/${op.id}/children`, {
+          children: op.data?.children || [],
+        });
+      }
+      break;
+
+    default:
+      throw new Error(`Unknown operation: ${op.op}`);
+  }
+}
+
+async function runWithConcurrency(
+  operations: BatchOperation[],
+  client: NotionClient,
+  concurrency: number,
+  stopOnError: boolean,
+): Promise<{ results: BatchResult[]; succeeded: number; failed: number }> {
+  const results: BatchResult[] = new Array(operations.length);
+  let succeeded = 0;
+  let failed = 0;
+  let stopped = false;
+
+  // Process in chunks of `concurrency` size
+  for (let start = 0; start < operations.length && !stopped; start += concurrency) {
+    const chunk = operations.slice(start, start + concurrency);
+
+    const chunkResults = await Promise.allSettled(
+      chunk.map(async (op, chunkIdx) => {
+        const index = start + chunkIdx;
+        const startTime = Date.now();
+
+        try {
+          const result = await executeOperation(client, op);
+          return {
+            index,
+            op: `${op.op} ${op.type}`,
+            success: true,
+            result,
+            durationMs: Date.now() - startTime,
+          } as BatchResult;
+        } catch (error) {
+          return {
+            index,
+            op: `${op.op} ${op.type}`,
+            success: false,
+            error: (error as Error).message,
+            durationMs: Date.now() - startTime,
+          } as BatchResult;
+        }
+      })
+    );
+
+    for (const settled of chunkResults) {
+      const result = settled.status === 'fulfilled'
+        ? settled.value
+        : { index: 0, op: 'unknown', success: false, error: 'Unexpected failure' } as BatchResult;
+
+      results[result.index] = result;
+
+      if (result.success) {
+        succeeded++;
+      } else {
+        failed++;
+        if (stopOnError) {
+          stopped = true;
+        }
+      }
+    }
+  }
+
+  return { results: results.filter(Boolean), succeeded, failed };
 }
 
 export function registerBatchCommand(program: Command): void {
@@ -30,11 +149,13 @@ export function registerBatchCommand(program: Command): void {
     .option('-d, --data <json>', 'Operations as JSON string')
     .option('--dry-run', 'Show what would be done without executing')
     .option('--stop-on-error', 'Stop execution on first error')
+    .option('--sequential', 'Execute operations one at a time')
+    .option('-c, --concurrency <number>', 'Max parallel operations (default: 3)', '3')
     .option('--llm', 'Output in LLM-friendly format')
     .action(async (options) => {
       try {
         let operations: BatchOperation[];
-        
+
         if (options.file) {
           const fs = await import('fs');
           const content = fs.readFileSync(options.file, 'utf-8');
@@ -50,11 +171,11 @@ export function registerBatchCommand(program: Command): void {
           const input = Buffer.concat(chunks).toString('utf-8');
           operations = JSON.parse(input);
         }
-        
+
         if (!Array.isArray(operations)) {
           operations = [operations];
         }
-        
+
         if (options.dryRun) {
           console.log('🔍 Dry run - would execute:');
           operations.forEach((op, i) => {
@@ -63,112 +184,22 @@ export function registerBatchCommand(program: Command): void {
           console.log(`\nTotal: ${operations.length} operations`);
           return;
         }
-        
+
         const client = getClient();
-        const results: BatchResult[] = [];
-        let succeeded = 0;
-        let failed = 0;
-        
-        for (let i = 0; i < operations.length; i++) {
-          const op = operations[i];
-          const result: BatchResult = {
-            index: i,
-            op: `${op.op} ${op.type}`,
-            success: false,
-          };
-          
-          try {
-            switch (op.op) {
-              case 'get':
-                if (op.type === 'page') {
-                  result.result = await client.get(`pages/${op.id}`);
-                } else if (op.type === 'database') {
-                  result.result = await client.get(`databases/${op.id}`);
-                } else if (op.type === 'block') {
-                  result.result = await client.get(`blocks/${op.id}`);
-                }
-                break;
-              
-              case 'create':
-                if (op.type === 'page') {
-                  const pageData = {
-                    parent: op.data?.parent_type === 'page' 
-                      ? { page_id: op.parent }
-                      : { database_id: op.parent },
-                    properties: op.data?.properties || {},
-                    children: op.data?.children || [],
-                  };
-                  result.result = await client.post('pages', pageData);
-                } else if (op.type === 'database') {
-                  const dbData = {
-                    parent: { page_id: op.parent },
-                    title: op.data?.title || [],
-                    properties: op.data?.properties || {},
-                  };
-                  result.result = await client.post('databases', dbData);
-                }
-                break;
-              
-              case 'update':
-                if (op.type === 'page') {
-                  result.result = await client.patch(`pages/${op.id}`, op.data || {});
-                } else if (op.type === 'database') {
-                  result.result = await client.patch(`databases/${op.id}`, op.data || {});
-                } else if (op.type === 'block') {
-                  result.result = await client.patch(`blocks/${op.id}`, op.data || {});
-                }
-                break;
-              
-              case 'delete':
-                if (op.type === 'block') {
-                  result.result = await client.delete(`blocks/${op.id}`);
-                } else {
-                  // Pages use archive
-                  result.result = await client.patch(`pages/${op.id}`, { archived: true });
-                }
-                break;
-              
-              case 'query':
-                if (op.type === 'database') {
-                  result.result = await client.post(`databases/${op.id}/query`, op.data || {});
-                }
-                break;
-              
-              case 'append':
-                if (op.type === 'block') {
-                  result.result = await client.patch(`blocks/${op.id}/children`, {
-                    children: op.data?.children || [],
-                  });
-                }
-                break;
-              
-              default:
-                throw new Error(`Unknown operation: ${op.op}`);
-            }
-            
-            result.success = true;
-            succeeded++;
-          } catch (error) {
-            result.error = (error as Error).message;
-            failed++;
-            
-            if (options.stopOnError) {
-              results.push(result);
-              break;
-            }
-          }
-          
-          results.push(result);
-        }
-        
+        const concurrency = (options.sequential || options.stopOnError) ? 1 : parseInt(options.concurrency, 10);
+
+        const { results, succeeded, failed } = await runWithConcurrency(
+          operations, client, concurrency, options.stopOnError
+        );
+
         // Output results
         if (options.llm) {
-          // LLM-friendly format
           console.log(`## Batch Results: ${succeeded}/${operations.length} succeeded\n`);
-          
+
           results.forEach(r => {
             const status = r.success ? '✅' : '❌';
-            console.log(`${status} [${r.index}] ${r.op}`);
+            const timing = r.durationMs !== undefined ? ` (${r.durationMs}ms)` : '';
+            console.log(`${status} [${r.index}] ${r.op}${timing}`);
             if (r.error) {
               console.log(`   Error: ${r.error}`);
             } else if (r.result) {
@@ -177,7 +208,7 @@ export function registerBatchCommand(program: Command): void {
               if (res.url) console.log(`   URL: ${res.url}`);
             }
           });
-          
+
           if (failed > 0) {
             console.log(`\n⚠️ ${failed} operations failed`);
           }
@@ -187,7 +218,7 @@ export function registerBatchCommand(program: Command): void {
             results,
           }));
         }
-        
+
         // Exit with error code if any failed
         if (failed > 0) {
           process.exit(1);


### PR DESCRIPTION
## Summary

Fixes #10

Batch operations were executing sequentially, making large batches unnecessarily slow. Now operations run in parallel with configurable concurrency.

## Changes

- Execute independent operations in parallel using `Promise.allSettled`
- Default concurrency of 3 (matches Notion API rate limit)
- `--concurrency <n>` flag to control parallelism
- `--sequential` flag to force sequential execution
- `--stop-on-error` implicitly forces sequential (can't stop mid-parallel)
- Per-operation timing reported in `--llm` output mode
- Extracted `executeOperation()` for cleaner code

## Test plan

- [x] All 23 batch tests pass
- [x] All 459 tests in full suite pass
- [x] stop-on-error still works (forces sequential)
- [x] Dry run unaffected