### PR TITLE
feat: add emoji icon and title rename support to page create/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,13 @@ notion page create --parent <db_id> --title "New Task"
 notion page create --parent <db_id> --title "Bug Fix" \
   --prop "Status=Todo" \
   --prop "Priority=High"
+notion page create --parent <db_id> --title "Meeting Notes" --icon 📝
 
 # Update page
 notion page update <page_id> --prop "Status=Done"
+notion page update <page_id> --title "New Title"
+notion page update <page_id> --icon 🚀
+notion page update <page_id> --prop "Status=Done" --icon ✅
 
 # Archive page
 notion page archive <page_id>

--- a/src/commands/pages.ts
+++ b/src/commands/pages.ts
@@ -61,6 +61,7 @@ export function registerPagesCommand(program: Command): void {
     .option('--title-prop <name>', 'Name of title property (auto-detected if not set)')
     .option('-p, --prop <key=value...>', 'Set property (can be used multiple times)')
     .option('-c, --content <text>', 'Initial page content (paragraph)')
+    .option('--icon <emoji>', 'Set page icon (emoji character, e.g. 📝)')
     .option('-j, --json', 'Output raw JSON')
     .action(async (options) => {
       try {
@@ -109,6 +110,10 @@ export function registerPagesCommand(program: Command): void {
 
         const body: Record<string, unknown> = { parent, properties };
 
+        if (options.icon) {
+          body.icon = { type: 'emoji', emoji: options.icon };
+        }
+
         // Add initial content if provided
         if (options.content) {
           body.children = [{
@@ -139,24 +144,67 @@ export function registerPagesCommand(program: Command): void {
   pages
     .command('update <page_id>')
     .description('Update page properties')
+    .option('-t, --title <title>', 'Rename the page title')
+    .option('--title-prop <name>', 'Name of title property (auto-detected if not set)')
     .option('-p, --prop <key=value...>', 'Set property (can be used multiple times)')
     .option('--archive', 'Archive the page')
     .option('--unarchive', 'Unarchive the page')
+    .option('--icon <emoji>', 'Set page icon (emoji character, e.g. 📝)')
     .option('-j, --json', 'Output raw JSON')
     .action(async (pageId: string, options) => {
       try {
         const client = getClient();
 
         const body: Record<string, unknown> = {};
+        const properties: Record<string, unknown> = {};
+
+        if (options.title) {
+          let titlePropName = options.titleProp;
+
+          if (!titlePropName) {
+            try {
+              const page = await client.get(`pages/${pageId}`) as {
+                parent: { type: string; database_id?: string };
+              };
+              if (page.parent.type === 'database_id' && page.parent.database_id) {
+                const db = await client.get(`databases/${page.parent.database_id}`) as {
+                  properties: Record<string, { type: string }>;
+                };
+                for (const [name, prop] of Object.entries(db.properties)) {
+                  if (prop.type === 'title') {
+                    titlePropName = name;
+                    break;
+                  }
+                }
+              }
+            } catch {
+              // Fall back to common default
+            }
+          }
+
+          titlePropName = titlePropName || 'Name';
+          properties[titlePropName] = {
+            title: [{ text: { content: options.title } }],
+          };
+        }
 
         if (options.prop) {
-          body.properties = parseProperties(options.prop);
+          const parsed = parseProperties(options.prop);
+          Object.assign(properties, parsed);
+        }
+
+        if (Object.keys(properties).length > 0) {
+          body.properties = properties;
         }
 
         if (options.archive) {
           body.archived = true;
         } else if (options.unarchive) {
           body.archived = false;
+        }
+
+        if (options.icon) {
+          body.icon = { type: 'emoji', emoji: options.icon };
         }
 
         const page = await client.patch(`pages/${pageId}`, body);

--- a/test/commands/pages.test.ts
+++ b/test/commands/pages.test.ts
@@ -247,6 +247,22 @@ describe('Pages Command', () => {
 
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('"object": "page"'));
     });
+
+    it('should create page with emoji icon', async () => {
+      const createdPage = { ...mockPage, id: 'new-page-123', url: 'https://notion.so/new-page-123' };
+      mockClient.post.mockResolvedValue(createdPage);
+
+      await program.parseAsync([
+        'node', 'test', 'page', 'create',
+        '--parent', 'db-123',
+        '--title', 'New Page',
+        '--icon', '📝',
+      ]);
+
+      expect(mockClient.post).toHaveBeenCalledWith('pages', expect.objectContaining({
+        icon: { type: 'emoji', emoji: '📝' },
+      }));
+    });
   });
 
   describe('page update', () => {
@@ -334,6 +350,93 @@ describe('Pages Command', () => {
       ]);
 
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('"object": "page"'));
+    });
+
+    it('should update page icon', async () => {
+      mockClient.patch.mockResolvedValue({ ...mockPage, id: 'page-123' });
+
+      await program.parseAsync([
+        'node', 'test', 'page', 'update', 'page-123',
+        '--icon', '🚀',
+      ]);
+
+      expect(mockClient.patch).toHaveBeenCalledWith('pages/page-123', {
+        icon: { type: 'emoji', emoji: '🚀' },
+      });
+    });
+
+    it('should update icon together with properties', async () => {
+      mockClient.patch.mockResolvedValue({ ...mockPage, id: 'page-123' });
+
+      await program.parseAsync([
+        'node', 'test', 'page', 'update', 'page-123',
+        '--prop', 'Status=Done',
+        '--icon', '✅',
+      ]);
+
+      expect(mockClient.patch).toHaveBeenCalledWith('pages/page-123', {
+        properties: { Status: { select: { name: 'Done' } } },
+        icon: { type: 'emoji', emoji: '✅' },
+      });
+    });
+
+    it('should rename title by auto-detecting title property from parent database', async () => {
+      // First call: get page (to find parent DB), second call: get DB schema
+      mockClient.get
+        .mockResolvedValueOnce(mockPage)
+        .mockResolvedValueOnce(mockDatabase);
+      mockClient.patch.mockResolvedValue({ ...mockPage, id: 'page-123' });
+
+      await program.parseAsync([
+        'node', 'test', 'page', 'update', 'page-123',
+        '--title', 'Renamed Page',
+      ]);
+
+      expect(mockClient.get).toHaveBeenCalledWith('pages/page-123');
+      expect(mockClient.get).toHaveBeenCalledWith('databases/db-123');
+      expect(mockClient.patch).toHaveBeenCalledWith('pages/page-123', {
+        properties: {
+          Name: { title: [{ text: { content: 'Renamed Page' } }] },
+        },
+      });
+    });
+
+    it('should rename title using explicit --title-prop without fetching schema', async () => {
+      mockClient.patch.mockResolvedValue({ ...mockPage, id: 'page-123' });
+
+      await program.parseAsync([
+        'node', 'test', 'page', 'update', 'page-123',
+        '--title', 'Renamed Page',
+        '--title-prop', 'Task Name',
+      ]);
+
+      // Should NOT fetch page or DB when --title-prop is provided
+      expect(mockClient.get).not.toHaveBeenCalled();
+      expect(mockClient.patch).toHaveBeenCalledWith('pages/page-123', {
+        properties: {
+          'Task Name': { title: [{ text: { content: 'Renamed Page' } }] },
+        },
+      });
+    });
+
+    it('should rename title together with other properties', async () => {
+      mockClient.get
+        .mockResolvedValueOnce(mockPage)
+        .mockResolvedValueOnce(mockDatabase);
+      mockClient.patch.mockResolvedValue({ ...mockPage, id: 'page-123' });
+
+      await program.parseAsync([
+        'node', 'test', 'page', 'update', 'page-123',
+        '--title', 'Renamed Page',
+        '--prop', 'Status=Done',
+      ]);
+
+      expect(mockClient.patch).toHaveBeenCalledWith('pages/page-123', {
+        properties: {
+          Name: { title: [{ text: { content: 'Renamed Page' } }] },
+          Status: { select: { name: 'Done' } },
+        },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Extends `page create` and `page update` with two new capabilities:

**Emoji icon support**
- `--icon <emoji>` on both `page create` and `page update`
- Passes `{ "type": "emoji", "emoji": "..." }` directly to the Notion API
- Can be combined with `--prop`, `--title`, `--archive`/`--unarchive` in a single command

**Title rename on `page update`**
- `--title <title>` renames the page title in-place (previously required create + archive workaround)
- Auto-detects the title property name by fetching the page → parent DB schema (same approach as `page create`)
- `--title-prop <name>` skips the schema lookup when the property name is known, avoiding 2 extra API calls

## Usage

```bash
# Set icon at creation
notion page create --parent <db_id> --title "Meeting Notes" --icon 📝

# Update icon
notion page update <page_id> --icon 🚀

# Rename title (auto-detects title property name)
notion page update <page_id> --title "New Title"

# Rename with explicit property name (zero extra API calls)
notion page update <page_id> --title "New Title" --title-prop "Task Name"

# Combine everything
notion page update <page_id> --title "New Title" --prop "Status=Done" --icon ✅
```

## Changes

- `src/commands/pages.ts` — added `--icon` to `page create` and `page update`; added `--title` / `--title-prop` to `page update`
- `test/commands/pages.test.ts` — 6 new test cases covering icon on create, icon on update, icon + props, title auto-detect, title with explicit `--title-prop`, title + props combined
- `README.md` — updated Basic Commands examples to reflect new flags

## Test plan

- [x] All 606 tests pass (`pnpm test`)
- [x] `notion page create --parent <db_id> --title "Test" --icon 📝` creates page with emoji icon
- [x] `notion page update <page_id> --icon 🚀` updates icon without touching other properties
- [x] `notion page update <page_id> --title "New Title"` renames title, auto-detecting the title property
- [x] `notion page update <page_id> --title "New Title" --title-prop "Task Name"` skips schema fetch