### PR TITLE
fix: use YAML block scalar in notion-onboarding description

### DIFF
--- a/skills/notion-onboarding/SKILL.md
+++ b/skills/notion-onboarding/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: notion-onboarding
-description: Discover and map a user's Notion workspace for the first time. Run this before any Notion workflows when no workspace state exists. Identifies key databases (projects, tasks, OKRs, home page, etc.) through guided discovery and saves them to a persistent state file so future interactions don't need to re-discover. Use when: first Notion setup, user says "set up Notion", "map my workspace", "onboard Notion", or when ~/.config/notion/workspace.json is missing.
+description: >
+  Discover and map a user's Notion workspace for the first time.
+  Run this before any Notion workflows when no workspace state exists.
+  Identifies key databases (projects, tasks, OKRs, home page, etc.)
+  through guided discovery and saves them to a persistent state file
+  so future interactions don't need to re-discover. Use when first
+  Notion setup, user says "set up Notion", "map my workspace",
+  "onboard Notion", or when ~/.config/notion/workspace.json is missing.
 ---
 
 # Notion Workspace Onboarding


### PR DESCRIPTION
As noted in #19 

Switch to YAML block scalar (`>`) to avoid special character issues.
This resolves skills.sh discovery of the notion-onboarding skill.

## Verification
Confirmed by merging fix in my fork into my main branch and running: 
```bash
$ npx skills add naokiiida/notion-cli-agent --list

███████╗██╗  ██╗██╗██╗     ██╗     ███████╗
██╔════╝██║ ██╔╝██║██║     ██║     ██╔════╝
███████╗█████╔╝ ██║██║     ██║     ███████╗
╚════██║██╔═██╗ ██║██║     ██║     ╚════██║
███████║██║  ██╗██║███████╗███████╗███████║
╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝╚══════╝

┌   skills
│
◇  Source: https://github.com/naokiiida/notion-cli-agent.git
│
◇  Repository cloned
│
◇  Found 2 skills

│
◇  Available Skills
│
│    notion-cli-agent
│
│      Use the local Notion CLI (notion-cli-agent) to query, create, update, and manage Notion pages and databases via shell. Use when interacting with Notion workspaces, querying databases, creating or updating pages, managing tasks, reading content blocks, or running bulk/batch operations on Notion data. Prefer over Notion MCP or API calls.
│
│    notion-onboarding
│
│      Discover and map a user's Notion workspace for the first time. Run this before any Notion workflows when no workspace state exists. Identifies key databases (projects, tasks, OKRs, home page, etc.) through guided discovery and saves them to a persistent state file so future interactions don't need to re-discover. Use when first Notion setup, user says "set up Notion", "map my workspace", "onboard Notion", or when ~/.config/notion/workspace.json is missing.
│

│
└  Use --skill <name> to install specific skills
```