### PR TITLE
Fix: `db query` drops all but last filter group when multiple `--filter-prop` flags are used

### DIFF
--- a/src/commands/databases.ts
+++ b/src/commands/databases.ts
@@ -73,6 +73,11 @@ export function registerDatabasesCommand(program: Command): void {
             process.exit(1);
           }
 
+          if (propTypes.length !== 0 && propTypes.length !== props.length) {
+            console.error('Error: --filter-prop-type must be provided either for all filter groups or for none');
+            process.exit(1);
+          }
+
           const filters = props.map((prop, i) =>
             parseFilter(prop, types[i], values[i], propTypes[i])
           );

--- a/test/commands/databases.test.ts
+++ b/test/commands/databases.test.ts
@@ -290,6 +290,25 @@ describe('Databases Command', () => {
       );
     });
 
+    it('should exit with error when --filter-prop-type count does not match filter group count', async () => {
+      await expect(
+        program.parseAsync([
+          'node', 'test', 'database', 'query', 'db-123',
+          '--filter-prop', 'Title',
+          '--filter-type', 'contains',
+          '--filter-value', 'foo',
+          '--filter-prop', 'Status',
+          '--filter-type', 'equals',
+          '--filter-value', 'Done',
+          '--filter-prop-type', 'status',
+        ])
+      ).rejects.toThrow('process.exit(1)');
+
+      expect(console.error).toHaveBeenCalledWith(
+        'Error: --filter-prop-type must be provided either for all filter groups or for none'
+      );
+    });
+
     it('should produce plain filter object for single filter group (regression)', async () => {
       const result = createPaginatedResult([mockPage]);
       mockClient.post.mockResolvedValue(result);


### PR DESCRIPTION
## Summary

Commander.js single-value options silently overwrite previous values on repeated use, so passing multiple `--filter-prop` / `--filter-type` / `--filter-value` / `--filter-prop-type` groups to `db query` would only apply the last group. Earlier filter groups were discarded without any warning.

## Changes

- Changed the four filter option definitions in `src/commands/databases.ts` to use a Commander.js collector function, so each flag accumulates into a `string[]` instead of being overwritten
- Replaced the single `parseFilter()` call with a loop that builds a `filters` array, then wraps it as `{ and: [...] }` when more than one group is present — matching the Notion API's compound filter syntax and the existing pattern in `find.ts`
- Added validation: if `--filter-prop`, `--filter-type`, and `--filter-value` are not passed the same number of times, the command now exits with a clear error message
- Updated option help text to indicate the flags are repeatable

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Single `--filter-prop` group | ✅ Plain filter object | ✅ Plain filter object (unchanged) |
| Multiple `--filter-prop` groups | ❌ Only last group applied | ✅ `{ and: [filter1, …, filterN] }` |
| Mismatched flag counts | ❌ Silent wrong result | ✅ Error message + exit 1 |
| `--filter <json>` raw option | ✅ Works | ✅ Works (unchanged) |

## Example

```sh
notion db query <database-id> \
  --filter-prop "Status" --filter-type equals --filter-value "In Progress" --filter-prop-type status \
  --filter-prop "Priority" --filter-type equals --filter-value "High" --filter-prop-type select
```

Previously only the `Priority` filter was applied. Now both are sent as:

```json
{
  "filter": {
    "and": [
      { "property": "Status", "status": { "equals": "In Progress" } },
      { "property": "Priority", "select": { "equals": "High" } }
    ]
  }
}
```

## Tests

Added 5 new test cases in `test/commands/databases.test.ts`:
- Two filter groups → `{ and: [filter1, filter2] }`
- Three filter groups → `{ and: [f1, f2, f3] }`
- Mismatched flag counts → `process.exit(1)` + error message
- Single filter group still produces a plain filter object (regression)
- `--filter <json>` raw option still works unchanged (regression)

All 20 tests pass.