### PR TITLE
fix: combine multiple --filter flags with AND logic

### DIFF
--- a/src/commands/databases.ts
+++ b/src/commands/databases.ts
@@ -41,7 +41,7 @@ export function registerDatabasesCommand(program: Command): void {
   databases
     .command('query <database_id>')
     .description('Query a database')
-    .option('-f, --filter <json>', 'Filter as JSON string')
+    .option('-f, --filter <json>', 'Filter as JSON string (repeatable)', (v: string, a: string[]) => [...a, v], [] as string[])
     .option('--filter-prop <property>', 'Property to filter on (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
     .option('--filter-type <type>', 'Filter type: equals, contains, etc. (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
     .option('--filter-value <value>', 'Filter value (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
@@ -70,8 +70,9 @@ export function registerDatabasesCommand(program: Command): void {
       }
 
       // Handle filter
-      if (!body.filter && options.filter) {
-        body.filter = JSON.parse(options.filter);
+      if (!body.filter && options.filter && options.filter.length > 0) {
+        const filters = options.filter.map((f: string) => JSON.parse(f));
+        body.filter = filters.length > 1 ? { and: filters } : filters[0];
       } else if (!body.filter && options.filterProp.length > 0) {
         const props: string[] = options.filterProp;
         const types: string[] = options.filterType;

--- a/test/commands/databases.test.ts
+++ b/test/commands/databases.test.ts
@@ -81,6 +81,30 @@ describe('Databases Command', () => {
       });
     });
 
+    it('should combine multiple --filter flags with AND logic', async () => {
+      setupDatabaseResolution(mockClient);
+      const result = createPaginatedResult([mockPage]);
+      mockClient.post.mockResolvedValue(result);
+
+      const filter1 = JSON.stringify({ property: 'Status', status: { equals: 'Done' } });
+      const filter2 = JSON.stringify({ property: 'Priority', select: { equals: 'High' } });
+      await program.parseAsync([
+        'node', 'test', 'database', 'query', 'db-123',
+        '--filter', filter1,
+        '--filter', filter2,
+      ]);
+
+      expect(mockClient.post).toHaveBeenCalledWith('data_sources/ds-456/query', {
+        filter: {
+          and: [
+            { property: 'Status', status: { equals: 'Done' } },
+            { property: 'Priority', select: { equals: 'High' } },
+          ],
+        },
+        page_size: 100,
+      });
+    });
+
     it('should query with simple filter options', async () => {
       setupDatabaseResolution(mockClient);
       const result = createPaginatedResult([mockPage]);


### PR DESCRIPTION
## Problem

When passing multiple `--filter` flags to `notion database query`, only the last filter is applied. Previous filters are silently dropped, returning incorrect results.

```bash
notion database query <db_id> \
  --filter '{"property":"Today","checkbox":{"equals":true}}' \
  --filter '{"property":"Status","status":{"does_not_equal":"Done"}}'
# Only the Status filter is sent — Today filter is ignored
```

## Root Cause

The `--filter` option (line 44, `databases.ts`) is defined without a Commander.js accumulator function, so it stores only the last value as a scalar string. The other repeatable filter options (`--filter-prop`, `--filter-type`, `--filter-value`) already use accumulators correctly — `--filter` was the odd one out.

## Fix

- Add an accumulator so `--filter` collects values into an array (matching the pattern used by `--filter-prop` et al.)
- When multiple filters are collected, wrap them in `{ "and": [...] }` before sending to the API
- Single `--filter` still passes through unchanged (backwards compatible)

## Tests

- Added test verifying multiple `--filter` flags produce an AND compound filter
- All 775 tests pass