### PR TITLE
feat: doctor command + database lookup by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`notion doctor`** — diagnostics command: checks token, API connectivity, workspace access, versions. `--json` supported. (#43)
+- **Database lookup by name** — `db get`, `db query` now accept database names instead of UUIDs. Resolves via `workspace.json` or API search. (#44)
+
 ## [0.14.0] - 2026-04-06
 
 ### Added

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,7 @@ import { registerBackupCommand } from './commands/backup.js';
 import { registerRelationsCommand } from './commands/relations.js';
 import { registerHelpAgentCommand } from './commands/help-agent.js';
 import { registerDedupCommand } from './commands/dedup.js';
+import { registerDoctorCommand } from './commands/doctor.js';
 
 const program = new Command();
 
@@ -85,6 +86,7 @@ registerValidateCommand(program);
 registerBackupCommand(program);
 registerRelationsCommand(program);
 registerDedupCommand(program);
+registerDoctorCommand(program);
 registerHelpAgentCommand(program);
 
 // Raw API command for advanced users

--- a/src/commands/databases.ts
+++ b/src/commands/databases.ts
@@ -4,7 +4,7 @@
 import { Command } from 'commander';
 import { getClient } from '../client.js';
 import { formatOutput, formatDatabaseTitle, parseFilter, formatResultsAsDelimited } from '../utils/format.js';
-import { getDatabaseSchema, queryDatabase, updateDatabase } from '../utils/database-resolver.js';
+import { getDatabaseSchema, queryDatabase, updateDatabase, resolveDatabaseId } from '../utils/database-resolver.js';
 import { withErrorHandler } from '../utils/command-handler.js';
 import { getPageTitle } from '../utils/notion-helpers.js';
 import type { Database, PaginatedResponse, Page } from '../types/notion.js';
@@ -18,11 +18,12 @@ export function registerDatabasesCommand(program: Command): void {
 
   // Get database
   databases
-    .command('get <database_id>')
-    .description('Retrieve a database by ID')
+    .command('get <database>')
+    .description('Retrieve a database by ID or name')
     .option('-j, --json', 'Output raw JSON')
-    .action(withErrorHandler(async (databaseId: string, options) => {
+    .action(withErrorHandler(async (database: string, options) => {
       const client = getClient();
+      const databaseId = await resolveDatabaseId(client, database);
       const db = await getDatabaseSchema(client, databaseId) as Database & Record<string, unknown>;
 
       if (options.json) {
@@ -39,8 +40,8 @@ export function registerDatabasesCommand(program: Command): void {
 
   // Query database
   databases
-    .command('query <database_id>')
-    .description('Query a database')
+    .command('query <database>')
+    .description('Query a database by ID or name')
     .option('-f, --filter <json>', 'Filter as JSON string (repeatable)', (v: string, a: string[]) => [...a, v], [] as string[])
     .option('--filter-prop <property>', 'Property to filter on (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
     .option('--filter-type <type>', 'Filter type: equals, contains, etc. (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
@@ -56,8 +57,9 @@ export function registerDatabasesCommand(program: Command): void {
     .option('--csv', 'Output as CSV')
     .option('--tsv', 'Output as TSV (tab-separated)')
     .option('--ids-only', 'Output only page IDs, one per line')
-    .action(withErrorHandler(async (databaseId: string, options) => {
+    .action(withErrorHandler(async (database: string, options) => {
       const client = getClient();
+      const databaseId = await resolveDatabaseId(client, database);
 
       const body: Record<string, unknown> = {};
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,96 @@
+/**
+ * Doctor command — quick diagnostics for troubleshooting
+ */
+import { Command } from 'commander';
+import { getClient, initClient } from '../client.js';
+import { formatOutput } from '../utils/format.js';
+import { withErrorHandler } from '../utils/command-handler.js';
+
+interface CheckResult {
+  name: string;
+  status: 'pass' | 'fail' | 'warn';
+  message: string;
+}
+
+export function registerDoctorCommand(program: Command): void {
+  program
+    .command('doctor')
+    .description('Run diagnostics: token, connectivity, permissions')
+    .option('-j, --json', 'Output as JSON')
+    .action(withErrorHandler(async (options) => {
+      const checks: CheckResult[] = [];
+
+      // 1. Token check
+      try {
+        initClient();
+        checks.push({ name: 'Token', status: 'pass', message: 'Token found and configured' });
+      } catch (error) {
+        checks.push({ name: 'Token', status: 'fail', message: (error as Error).message });
+      }
+
+      // 2. API connectivity + auth
+      let userId = '';
+      try {
+        const client = getClient();
+        const me = await client.get('users/me') as { id: string; name?: string; type: string };
+        userId = me.id;
+        const name = me.name || me.type;
+        checks.push({ name: 'API Connection', status: 'pass', message: `Authenticated as ${name} (${me.type})` });
+      } catch (error) {
+        const msg = (error as Error).message;
+        if (msg.includes('401')) {
+          checks.push({ name: 'API Connection', status: 'fail', message: 'Token is invalid or expired' });
+        } else if (msg.includes('fetch') || msg.includes('ENOTFOUND')) {
+          checks.push({ name: 'API Connection', status: 'fail', message: 'Cannot reach Notion API — check network' });
+        } else {
+          checks.push({ name: 'API Connection', status: 'fail', message: msg });
+        }
+      }
+
+      // 3. Workspace access
+      if (userId) {
+        try {
+          const client = getClient();
+          const result = await client.post('search', { page_size: 1 }) as { results: unknown[] };
+          if (result.results.length > 0) {
+            checks.push({ name: 'Workspace Access', status: 'pass', message: 'Integration has access to workspace content' });
+          } else {
+            checks.push({
+              name: 'Workspace Access',
+              status: 'warn',
+              message: 'No pages or databases accessible. Share content with your integration in Notion.',
+            });
+          }
+        } catch (error) {
+          checks.push({ name: 'Workspace Access', status: 'fail', message: (error as Error).message });
+        }
+      }
+
+      // 4. API version
+      checks.push({ name: 'API Version', status: 'pass', message: '2026-03-11' });
+
+      // 5. CLI version
+      const { createRequire } = await import('module');
+      const require = createRequire(import.meta.url);
+      const { version } = require('../../package.json');
+      checks.push({ name: 'CLI Version', status: 'pass', message: version });
+
+      // Output
+      if (options.json) {
+        console.log(formatOutput(checks));
+        return;
+      }
+
+      console.log('\nNotion CLI Doctor\n');
+      const passed = checks.filter(c => c.status === 'pass').length;
+      for (const check of checks) {
+        const icon = check.status === 'pass' ? '✅' : check.status === 'warn' ? '⚠️' : '❌';
+        console.log(`${icon} ${check.name}: ${check.message}`);
+      }
+      console.log(`\n${passed}/${checks.length} checks passed`);
+
+      if (checks.some(c => c.status === 'fail')) {
+        process.exit(1);
+      }
+    }));
+}

--- a/src/utils/database-resolver.ts
+++ b/src/utils/database-resolver.ts
@@ -67,6 +67,67 @@ export function clearResolverCache(): void {
   cache.clear();
 }
 
+// ─── Name-based database lookup ──────────────────────────────────────────────
+
+// Looks like an ID if it's only hex digits and dashes (no spaces, no letters beyond a-f)
+const ID_RE = /^[0-9a-f][0-9a-f-]*$/i;
+
+/**
+ * Resolve a database identifier that may be an ID or a human-readable name.
+ * If it looks like an ID (hex chars, dashes), returns it as-is. Otherwise:
+ * 1. Checks ~/.config/notion/workspace.json for a matching database name
+ * 2. Falls back to API search
+ * Throws if no match or multiple ambiguous matches.
+ */
+export async function resolveDatabaseId(
+  client: NotionClient,
+  idOrName: string,
+): Promise<string> {
+  if (ID_RE.test(idOrName)) return idOrName;
+
+  const lowerName = idOrName.toLowerCase().trim();
+
+  // Try workspace.json first
+  try {
+    const fs = await import('fs');
+    const path = await import('path');
+    const os = await import('os');
+    const wsPath = path.join(os.homedir(), '.config', 'notion', 'workspace.json');
+    if (fs.existsSync(wsPath)) {
+      const ws = JSON.parse(fs.readFileSync(wsPath, 'utf-8'));
+      const databases = ws.databases || {};
+      for (const [key, db] of Object.entries(databases)) {
+        const entry = db as { id?: string; name?: string };
+        const name = (entry.name || key).toLowerCase();
+        if (name === lowerName) return entry.id || key;
+      }
+    }
+  } catch {
+    // workspace.json not found or malformed — fall through to search
+  }
+
+  // Fall back to API search — returns data_source objects on v2026-03-11
+  const result = await client.post<{ results: { id: string; title?: { plain_text: string }[]; parent?: { database_id?: string } }[] }>('search', {
+    query: idOrName,
+    filter: { property: 'object', value: 'data_source' },
+    page_size: 10,
+  });
+
+  const matches = result.results.filter(r => {
+    const title = r.title?.map(t => t.plain_text).join('').toLowerCase() || '';
+    return title === lowerName;
+  });
+
+  // Return the parent database_id if available, otherwise the data_source id
+  if (matches.length === 1) return matches[0].parent?.database_id || matches[0].id;
+  if (matches.length > 1) {
+    const list = matches.map(m => `  - ${m.id} (${m.title?.map(t => t.plain_text).join('')})`).join('\n');
+    throw new Error(`Ambiguous database name "${idOrName}" matches ${matches.length} databases:\n${list}\nUse the database ID instead.`);
+  }
+
+  throw new Error(`Database "${idOrName}" not found. Use 'notion inspect ws' to list accessible databases, or pass the database ID directly.`);
+}
+
 // ─── Core resolution ────────────────────────────────────────────────────────
 
 function buildPaths(dataSourceId: string) {

--- a/test/commands/databases.test.ts
+++ b/test/commands/databases.test.ts
@@ -459,7 +459,7 @@ describe('Databases Command', () => {
       mockClient.get.mockRejectedValue(new Error('Database not found'));
 
       await expect(
-        program.parseAsync(['node', 'test', 'database', 'get', 'invalid-id'])
+        program.parseAsync(['node', 'test', 'database', 'get', 'bad-db-000'])
       ).rejects.toThrow('process.exit(1)');
 
       expect(console.error).toHaveBeenCalledWith('Error:', 'Database not found');


### PR DESCRIPTION
Closes #43, partially addresses #44

## notion doctor

```bash
notion doctor

# Notion CLI Doctor
#
# ✅ Token: Token found and configured
# ✅ API Connection: Authenticated as Klaus (bot)
# ✅ Workspace Access: Integration has access to workspace content
# ✅ API Version: 2026-03-11
# ✅ CLI Version: 0.14.0
#
# 5/5 checks passed
```

## Database lookup by name

`db get` and `db query` now accept names instead of UUIDs:

```bash
notion db query "Proyectos" --llm --limit 5
notion db get "Clases 2026" --json
```

Resolution order:
1. If it looks like an ID (hex chars + dashes), use as-is
2. Check `~/.config/notion/workspace.json` for name match
3. Fall back to API search (exact title match)

## Test plan
- [x] 807 tests pass, 0 failures
- [x] Build clean
- [x] Tested doctor and name lookup against live API