### PR TITLE
feat: markdown API for page edit, export, backup, and comments

### DIFF
--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -5,8 +5,7 @@ import { Command } from 'commander';
 import { getClient } from '../client.js';
 import * as fs from 'fs';
 import * as path from 'path';
-import { blocksToMarkdownSync } from '../utils/markdown.js';
-import { fetchAllBlocks, getPageTitle, getDbTitle, getPropertyRawValue } from '../utils/notion-helpers.js';
+import { fetchAllBlocks, getPageMarkdown, getPageTitle, getDbTitle, getPropertyRawValue } from '../utils/notion-helpers.js';
 import { getDatabaseSchema, queryAllPages } from '../utils/database-resolver.js';
 import { withErrorHandler } from '../utils/command-handler.js';
 import { resolveDatabaseInput } from '../utils/workspace-resolver.js';
@@ -116,23 +115,29 @@ export function registerBackupCommand(program: Command): void {
             properties: entry.properties,
           };
           
-          // Fetch content if requested
-          if (options.content) {
-            try {
-              const blocks = await fetchBlocksRecursive(client, entry.id);
-              pageData.content = blocks;
-            } catch (error) {
-              pageData.content_error = (error as Error).message;
-            }
-          }
-          
           // Save based on format
           if (options.format === 'markdown') {
-            const mdContent = generateMarkdown(entry, pageData.content as Block[] | undefined);
+            // Use native markdown API (1 call per page, no recursive block fetch)
+            let mdContent = generateMarkdownFrontmatter(entry);
+            try {
+              const { markdown } = await getPageMarkdown(client, entry.id);
+              mdContent += markdown;
+            } catch {
+              mdContent += `<!-- Failed to fetch content -->\n`;
+            }
             const filePath = path.join(pagesDir, `${filename}.md`);
             fs.writeFileSync(filePath, mdContent);
             totalSize += mdContent.length;
           } else {
+            // JSON format: fetch recursive blocks
+            if (options.content) {
+              try {
+                const blocks = await fetchBlocksRecursive(client, entry.id);
+                pageData.content = blocks;
+              } catch (error) {
+                pageData.content_error = (error as Error).message;
+              }
+            }
             const jsonContent = JSON.stringify(pageData, null, 2);
             const filePath = path.join(pagesDir, `${filename}.json`);
             fs.writeFileSync(filePath, jsonContent);
@@ -178,22 +183,18 @@ export function registerBackupCommand(program: Command): void {
     }));
 }
 
-function generateMarkdown(page: Page, blocks?: Block[]): string {
+function generateMarkdownFrontmatter(page: Page): string {
   const title = getPageTitle(page);
-  let md = '';
-  
-  // Frontmatter
-  md += '---\n';
+  let md = '---\n';
   md += `notion_id: "${page.id}"\n`;
   if (page.url) md += `notion_url: "${page.url}"\n`;
   md += `created: ${(page.created_time || '').split('T')[0]}\n`;
   md += `updated: ${(page.last_edited_time || '').split('T')[0]}\n`;
-  
-  // Properties
+
   for (const [name, value] of Object.entries(page.properties)) {
     const prop = value as { type: string; [key: string]: unknown };
     if (prop.type === 'title') continue;
-    
+
     const val = getPropertyRawValue(prop);
     if (val !== null && val !== '') {
       const safeName = name.toLowerCase().replace(/[^a-z0-9]/g, '_');
@@ -207,15 +208,9 @@ function generateMarkdown(page: Page, blocks?: Block[]): string {
       }
     }
   }
-  
+
   md += '---\n\n';
   md += `# ${title}\n\n`;
-  
-  // Content — use shared blocksToMarkdownSync with rich text annotations
-  if (blocks) {
-    md += blocksToMarkdownSync(blocks);
-  }
-  
   return md;
 }
 

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -117,13 +117,14 @@ export function registerBackupCommand(program: Command): void {
           
           // Save based on format
           if (options.format === 'markdown') {
-            // Use native markdown API (1 call per page, no recursive block fetch)
             let mdContent = generateMarkdownFrontmatter(entry);
-            try {
-              const { markdown } = await getPageMarkdown(client, entry.id);
-              mdContent += markdown;
-            } catch {
-              mdContent += `<!-- Failed to fetch content -->\n`;
+            if (options.content) {
+              try {
+                const { markdown } = await getPageMarkdown(client, entry.id);
+                mdContent += markdown;
+              } catch {
+                mdContent += `<!-- Failed to fetch content -->\n`;
+              }
             }
             const filePath = path.join(pagesDir, `${filename}.md`);
             fs.writeFileSync(filePath, mdContent);

--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -88,6 +88,7 @@ export function registerCommentsCommand(program: Command): void {
     .option('--page <page_id>', 'Page ID to comment on (starts new discussion)')
     .option('--discussion <discussion_id>', 'Discussion ID to reply to')
     .requiredOption('-t, --text <text>', 'Comment text')
+    .option('-m, --markdown', 'Treat text as markdown (supports **bold**, [links](url), etc.)')
     .option('-j, --json', 'Output raw JSON')
     .action(withErrorHandler(async (options) => {
       if (!options.page && !options.discussion) {
@@ -97,9 +98,13 @@ export function registerCommentsCommand(program: Command): void {
 
       const client = getClient();
 
-      const body: Record<string, unknown> = {
-        rich_text: [{ type: 'text', text: { content: options.text } }],
-      };
+      const body: Record<string, unknown> = {};
+
+      if (options.markdown) {
+        body.markdown = options.text;
+      } else {
+        body.rich_text = [{ type: 'text', text: { content: options.text } }];
+      }
 
       if (options.page) {
         body.parent = { page_id: options.page };

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -9,7 +9,7 @@ import {
   richTextToMarkdown,
 } from '../utils/markdown.js';
 import { queryAllPages } from '../utils/database-resolver.js';
-import { blocksToMarkdownAsync, getPropertyRawValue } from '../utils/notion-helpers.js';
+import { getPageMarkdown, getPropertyRawValue } from '../utils/notion-helpers.js';
 import { withErrorHandler } from '../utils/command-handler.js';
 import { resolveDatabaseInput } from '../utils/workspace-resolver.js';
 import type { RichText, Page } from '../types/notion.js';
@@ -118,10 +118,10 @@ export function registerExportCommand(program: Command): void {
       // Add title
       output += `# ${title}\n\n`;
 
-      // Add content
+      // Add content via native markdown API
       if (options.content !== false) {
-        const content = await blocksToMarkdownAsync(client, pageId);
-        output += content;
+        const { markdown } = await getPageMarkdown(client, pageId);
+        output += markdown;
       }
 
       // Output
@@ -176,7 +176,7 @@ export function registerExportCommand(program: Command): void {
 
           if (options.content) {
             try {
-              const pageContent = await blocksToMarkdownAsync(client, page.id);
+              const { markdown: pageContent } = await getPageMarkdown(client, page.id);
               content += pageContent;
             } catch {
               content += `<!-- Failed to fetch content -->\n`;

--- a/src/commands/pages.ts
+++ b/src/commands/pages.ts
@@ -448,7 +448,11 @@ export function registerPagesCommand(program: Command): void {
 
       // Search-and-replace mode (native markdown API, 1 call)
       if (options.find) {
-        const newText = options.replaceText ?? '';
+        if (options.replaceText === undefined) {
+          console.error('Error: --replace-text is required with --find (use --replace-text "" to explicitly delete)');
+          process.exit(1);
+        }
+        const newText = options.replaceText;
         if (options.dryRun) {
           console.log(`Would replace "${options.find}" with "${newText}"${options.replaceAll ? ' (all occurrences)' : ''}`);
           console.log('\nDry run - no changes made');

--- a/src/commands/pages.ts
+++ b/src/commands/pages.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import { getClient } from '../client.js';
 import { formatOutput, formatPageTitle, parseProperties } from '../utils/format.js';
 import { markdownToBlocks } from '../utils/markdown.js';
-import { blocksToMarkdownAsync, fetchAllBlocks, getPageMarkdown, replacePageMarkdown, getPageTitle, isParentDatabase, getParentDatabaseId, resolvePropertyName, buildClearPayload, buildTrashPayload, buildBlockPosition } from '../utils/notion-helpers.js';
+import { blocksToMarkdownAsync, fetchAllBlocks, getPageMarkdown, replacePageMarkdown, updatePageMarkdown, getPageTitle, isParentDatabase, getParentDatabaseId, resolvePropertyName, buildClearPayload, buildTrashPayload, buildBlockPosition } from '../utils/notion-helpers.js';
 import { getDatabaseSchema } from '../utils/database-resolver.js';
 import { withErrorHandler } from '../utils/command-handler.js';
 import type { Page } from '../types/notion.js';
@@ -432,9 +432,12 @@ export function registerPagesCommand(program: Command): void {
   // Surgical page editing
   pages
     .command('edit <page_id>')
-    .description('Surgical block-level editing: delete, insert, or replace blocks at a position')
-    .option('--after <block_id>', 'Position: insert after this block ID')
-    .option('--at <index>', 'Position: operate at this block index (0-based)')
+    .description('Edit page content: search-and-replace via markdown API, or block-level insert/delete')
+    .option('--find <text>', 'Text to find (uses native markdown search-and-replace)')
+    .option('--replace-text <text>', 'Replacement text (use with --find)')
+    .option('--replace-all', 'Replace all occurrences (use with --find)')
+    .option('--after <block_id>', 'Position: insert after this block ID (block-level mode)')
+    .option('--at <index>', 'Position: operate at this block index (block-level mode)')
     .option('--delete <count>', 'Delete <count> blocks starting at position', parseInt)
     .option('-f, --file <path>', 'Read replacement Markdown from file')
     .option('-m, --markdown <text>', 'Replacement Markdown text (inline)')
@@ -442,6 +445,19 @@ export function registerPagesCommand(program: Command): void {
     .option('-j, --json', 'Output raw JSON')
     .action(withErrorHandler(async (pageId: string, options) => {
       const client = getClient();
+
+      // Search-and-replace mode (native markdown API, 1 call)
+      if (options.find) {
+        const newText = options.replaceText ?? '';
+        if (options.dryRun) {
+          console.log(`Would replace "${options.find}" with "${newText}"${options.replaceAll ? ' (all occurrences)' : ''}`);
+          console.log('\nDry run - no changes made');
+          return;
+        }
+        await updatePageMarkdown(client, pageId, options.find, newText, !!options.replaceAll);
+        console.log(`Replaced "${options.find}" with "${newText}"${options.replaceAll ? ' (all occurrences)' : ''}`);
+        return;
+      }
 
         // Fetch all current blocks
         const allBlocks = await fetchAllBlocks(client, pageId);

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -335,20 +335,26 @@ export async function startMcpServer(): Promise<void> {
       // --- Comments -----------------------------------------------------
 
       comment_create: {
-        description: 'Create a comment on a page',
+        description: 'Create a comment on a page (supports markdown formatting)',
         parameters: {
           type: 'object',
           properties: {
             page_id: { type: 'string', description: 'Page ID to comment on' },
-            text: { type: 'string', description: 'Comment text' },
+            text: { type: 'string', description: 'Comment text (plain or markdown)' },
+            markdown: { type: 'boolean', description: 'Treat text as markdown' },
           },
           required: ['page_id', 'text'],
         },
         handler: async (params) => {
-          const comment = await client.post('comments', {
+          const body: Record<string, unknown> = {
             parent: { page_id: params.page_id },
-            rich_text: [{ type: 'text', text: { content: params.text } }],
-          });
+          };
+          if (params.markdown) {
+            body.markdown = params.text;
+          } else {
+            body.rich_text = [{ type: 'text', text: { content: params.text } }];
+          }
+          const comment = await client.post('comments', body);
           return JSON.stringify(comment);
         },
       },

--- a/src/utils/notion-helpers.ts
+++ b/src/utils/notion-helpers.ts
@@ -120,6 +120,25 @@ export async function replacePageMarkdown(
   });
 }
 
+/**
+ * Search-and-replace within a page's markdown content.
+ * Uses the update_content command for surgical edits without replacing the full page.
+ */
+export async function updatePageMarkdown(
+  client: ReturnType<typeof getClient>,
+  pageId: string,
+  oldStr: string,
+  newStr: string,
+  replaceAll = false,
+): Promise<void> {
+  await client.patch(`pages/${pageId}/markdown`, {
+    type: 'update_content',
+    update_content: {
+      content_updates: [{ old_str: oldStr, new_str: newStr, ...(replaceAll ? { replace_all_matches: true } : {}) }],
+    },
+  });
+}
+
 // ─── Title Extraction ───────────────────────────────────────────────────────
 
 /**

--- a/test/commands/backup.test.ts
+++ b/test/commands/backup.test.ts
@@ -231,15 +231,19 @@ describe('Backup Command', () => {
 
     it('should include content in markdown format', async () => {
       setupDatabaseResolution(mockClient);
-      mockClient.get.mockResolvedValue(mockBlocks);
+      mockClient.get.mockResolvedValue({
+        object: 'page_markdown',
+        markdown: 'Backup content here.\n',
+        truncated: false,
+      });
       mockClient.post.mockResolvedValue(createPaginatedResult([mockPage]));
 
-      await program.parseAsync(['node', 'test', 'backup', 'db-123', '--output', '/backup', '--content', '--format', 'markdown']);
+      await program.parseAsync(['node', 'test', 'backup', 'db-123', '--output', '/backup', '--format', 'markdown']);
 
       const mdFiles = Array.from(mockFS.keys()).filter(k => k.startsWith('/backup/pages/') && k.endsWith('.md'));
+      expect(mdFiles.length).toBe(1);
       const mdContent = mockFS.get(mdFiles[0]) || '';
-      expect(mdContent).toContain('# Title');
-      expect(mdContent).toContain('Content');
+      expect(mdContent).toContain('Backup content here.');
     });
   });
 

--- a/test/commands/backup.test.ts
+++ b/test/commands/backup.test.ts
@@ -238,7 +238,7 @@ describe('Backup Command', () => {
       });
       mockClient.post.mockResolvedValue(createPaginatedResult([mockPage]));
 
-      await program.parseAsync(['node', 'test', 'backup', 'db-123', '--output', '/backup', '--format', 'markdown']);
+      await program.parseAsync(['node', 'test', 'backup', 'db-123', '--output', '/backup', '--format', 'markdown', '--content']);
 
       const mdFiles = Array.from(mockFS.keys()).filter(k => k.startsWith('/backup/pages/') && k.endsWith('.md'));
       expect(mdFiles.length).toBe(1);

--- a/test/commands/export.test.ts
+++ b/test/commands/export.test.ts
@@ -69,17 +69,23 @@ describe('Export Command', () => {
       has_more: false,
     };
 
+    const mockMarkdownResponse = {
+      object: 'page_markdown',
+      markdown: '# Introduction\n\nThis is content.\n',
+      truncated: false,
+    };
+
     it('should export page to stdout by default', async () => {
       mockClient.get.mockImplementation(async (path: string) => {
+        if (path.endsWith('/markdown')) return mockMarkdownResponse;
         if (path.startsWith('pages/')) return mockPageWithBlocks;
-        if (path.startsWith('blocks/')) return mockBlocks;
         throw new Error('Unexpected path');
       });
 
       await program.parseAsync(['node', 'test', 'export', 'page', 'page-123']);
 
       expect(mockClient.get).toHaveBeenCalledWith('pages/page-123');
-      expect(mockClient.get).toHaveBeenCalledWith('blocks/page-123/children');
+      expect(mockClient.get).toHaveBeenCalledWith('pages/page-123/markdown');
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('# Test Page'));
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('# Introduction'));
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('This is content.'));
@@ -87,8 +93,8 @@ describe('Export Command', () => {
 
     it('should export page to file with --output', async () => {
       mockClient.get.mockImplementation(async (path: string) => {
+        if (path.endsWith('/markdown')) return mockMarkdownResponse;
         if (path.startsWith('pages/')) return mockPageWithBlocks;
-        if (path.startsWith('blocks/')) return mockBlocks;
         throw new Error('Unexpected path');
       });
 
@@ -134,8 +140,8 @@ describe('Export Command', () => {
 
     it('should export without frontmatter when --no-frontmatter is used', async () => {
       mockClient.get.mockImplementation(async (path: string) => {
+        if (path.endsWith('/markdown')) return mockMarkdownResponse;
         if (path.startsWith('pages/')) return mockPageWithBlocks;
-        if (path.startsWith('blocks/')) return mockBlocks;
         throw new Error('Unexpected path');
       });
 
@@ -147,149 +153,18 @@ describe('Export Command', () => {
       expect(content).toContain('# Introduction');
     });
 
-    it('should handle paginated blocks', async () => {
-      const firstBatch = {
-        results: [mockBlocks.results[0]],
-        has_more: true,
-        next_cursor: 'cursor-123',
-      };
-      const secondBatch = {
-        results: [mockBlocks.results[1]],
-        has_more: false,
-      };
-
-      let callCount = 0;
+    it('should use native markdown API for content (single call, no block pagination)', async () => {
       mockClient.get.mockImplementation(async (path: string) => {
+        if (path.endsWith('/markdown')) return mockMarkdownResponse;
         if (path.startsWith('pages/')) return mockPageWithBlocks;
-        if (path.startsWith('blocks/page-123/children?start_cursor=')) return secondBatch;
-        if (path.startsWith('blocks/')) {
-          callCount++;
-          if (callCount === 1) return firstBatch;
-          return secondBatch;
-        }
         throw new Error('Unexpected path');
       });
 
       await program.parseAsync(['node', 'test', 'export', 'page', 'page-123']);
 
-      expect(mockClient.get).toHaveBeenCalledWith('blocks/page-123/children');
-      expect(mockClient.get).toHaveBeenCalledWith('blocks/page-123/children?start_cursor=cursor-123');
-    });
-
-    it('should handle blocks with rich text annotations', async () => {
-      const richTextBlock = {
-        results: [
-          {
-            id: 'block-1',
-            type: 'paragraph',
-            paragraph: {
-              rich_text: [
-                {
-                  type: 'text',
-                  plain_text: 'bold text',
-                  annotations: { bold: true },
-                },
-                {
-                  type: 'text',
-                  plain_text: ' italic ',
-                  annotations: { italic: true },
-                },
-                {
-                  type: 'text',
-                  plain_text: 'code',
-                  annotations: { code: true },
-                },
-              ],
-            },
-            has_children: false,
-          },
-        ],
-        has_more: false,
-      };
-
-      mockClient.get.mockImplementation(async (path: string) => {
-        if (path.startsWith('pages/')) return mockPageWithBlocks;
-        if (path.startsWith('blocks/')) return richTextBlock;
-        throw new Error('Unexpected path');
-      });
-
-      await program.parseAsync(['node', 'test', 'export', 'page', 'page-123']);
-
-      const output = (console.log as any).mock.calls[0][0];
-      expect(output).toContain('**bold text**');
-      expect(output).toContain('* italic *'); // Note: spaces included in plain_text
-      expect(output).toContain('`code`');
-    });
-
-    it('should convert different block types to markdown', async () => {
-      const mixedBlocks = {
-        results: [
-          {
-            id: 'b1',
-            type: 'heading_1',
-            heading_1: { rich_text: [{ type: 'text', plain_text: 'H1' }] },
-            has_children: false,
-          },
-          {
-            id: 'b2',
-            type: 'heading_2',
-            heading_2: { rich_text: [{ type: 'text', plain_text: 'H2' }] },
-            has_children: false,
-          },
-          {
-            id: 'b3',
-            type: 'bulleted_list_item',
-            bulleted_list_item: { rich_text: [{ type: 'text', plain_text: 'Bullet' }] },
-            has_children: false,
-          },
-          {
-            id: 'b4',
-            type: 'to_do',
-            to_do: { rich_text: [{ type: 'text', plain_text: 'Todo' }], checked: false },
-            has_children: false,
-          },
-          {
-            id: 'b5',
-            type: 'quote',
-            quote: { rich_text: [{ type: 'text', plain_text: 'Quote' }] },
-            has_children: false,
-          },
-          {
-            id: 'b6',
-            type: 'divider',
-            divider: {},
-            has_children: false,
-          },
-          {
-            id: 'b7',
-            type: 'code',
-            code: {
-              rich_text: [{ type: 'text', plain_text: 'console.log("hello")' }],
-              language: 'javascript',
-            },
-            has_children: false,
-          },
-        ],
-        has_more: false,
-      };
-
-      mockClient.get.mockImplementation(async (path: string) => {
-        if (path.startsWith('pages/')) return mockPageWithBlocks;
-        if (path.startsWith('blocks/')) return mixedBlocks;
-        throw new Error('Unexpected path');
-      });
-
-      await program.parseAsync(['node', 'test', 'export', 'page', 'page-123']);
-
-      const output = (console.log as any).mock.calls[0][0];
-      expect(output).toContain('# H1');
-      expect(output).toContain('## H2');
-      expect(output).toContain('- Bullet');
-      expect(output).toContain('- [ ] Todo');
-      expect(output).toContain('> Quote');
-      expect(output).toContain('---');
-      expect(output).toContain('```javascript');
-      expect(output).toContain('console.log("hello")');
+      expect(mockClient.get).toHaveBeenCalledWith('pages/page-123/markdown');
+      // Should NOT fetch blocks directly
+      expect(mockClient.get).not.toHaveBeenCalledWith(expect.stringContaining('blocks/'));
     });
   });
 
@@ -318,15 +193,18 @@ describe('Export Command', () => {
     });
 
     it('should export with content when --content is specified', async () => {
-      const mockPageBlocks = { results: [{ id: 'b1', type: 'paragraph', paragraph: { rich_text: [{ type: 'text', plain_text: 'Content' }] }, has_children: false }], has_more: false };
       setupDatabaseResolution(mockClient);
       mockClient.post.mockResolvedValue(createPaginatedResult([mockPage]));
-      mockClient.get.mockResolvedValue(mockPageBlocks);
+      mockClient.get.mockResolvedValue({
+        object: 'page_markdown',
+        markdown: 'Page content here.\n',
+        truncated: false,
+      });
 
       await program.parseAsync(['node', 'test', 'export', 'database', 'db-123', '--vault', '/vault', '--content']);
 
       const pageContent = mockFS.get('/vault/Test Page.md') || '';
-      expect(pageContent).toContain('Content');
+      expect(pageContent).toContain('Page content here.');
     });
 
     it('should respect --limit option', async () => {


### PR DESCRIPTION
## Summary

Three issues in one PR, all extending the native Notion markdown API integration:

### #52: Page edit with search-and-replace
```bash
notion page edit <id> --find "DRAFT" --replace-text "FINAL"
notion page edit <id> --find "old text" --replace-text "new text" --replace-all
```
Single PATCH call. No more calculating block positions. The existing block-level `--at`/`--after` editing is preserved as-is.

### #53: Native markdown for export and backup
- `export page/db`: uses `GET /pages/:id/markdown` instead of recursive block fetching
- `backup --format markdown`: same, eliminates `fetchBlocksRecursive` + `blocksToMarkdownSync` for markdown backups
- JSON backups still use recursive block fetch (preserves full block structure)

### #54: Markdown in comments
```bash
notion comment create --page <id> --text "**bold** and [link](url)" --markdown
```

### MCP updates
- `comment_create`: accepts `markdown` boolean param

## Impact
- `page edit --find/--replace-text`: 1 API call vs fetch-all-blocks + compute-position + delete + insert
- `export db --content` with 100 pages: 100 calls vs 100+ (recursive children)
- `backup --format markdown`: 1 call per page vs N (recursive tree traversal)
- Net -77 lines

## Test plan
- [x] `pnpm build` compiles
- [x] 806 tests pass, 0 failures
- [x] Manual: `page edit --find "DRAFT" --replace-text "FINAL"` works on real API
- [x] Manual: export uses native markdown
- [x] Manual: backup --format markdown works

Closes #52, closes #53, closes #54